### PR TITLE
Add CI workflow to build and deploy documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,42 @@
+name: Build and deploy documentation
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install pandoc (required by nbsphinx)
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+
+      - name: Install package and documentation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[all,docs]"
+
+      - name: Build documentation
+        run: sphinx-build -W -b html docs/source docs/_build/html
+
+      - name: Deploy to gh-pages
+        if: github.ref == 'refs/heads/master'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html
+          publish_branch: gh-pages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,15 @@ all = [
     "diff-pdf-visually",
     "ipython!=8.7.0",
 ]
+docs = [
+    "sphinx",
+    "furo",
+    "sphinx-click",
+    "sphinx-mdinclude",
+    "nbsphinx",
+    "alabaster",
+    "ipython!=8.7.0",
+]
 
 [project.scripts]
 pygenstability = "pygenstability.app:cli"


### PR DESCRIPTION
## Summary

Automates documentation deployment, replacing the manual `make full` (which built locally and pushed to `gh-pages` from a sibling checkout). Answers the "redeploy the docs / have a CI job do it" request — both, since merging this also redeploys.

## What it does

New workflow `.github/workflows/docs.yml`:
- **On push to `master`** — builds the Sphinx docs (`sphinx-build -W`, warnings-as-errors, matching the Makefile) and deploys the result to the `gh-pages` branch via `peaceiris/actions-gh-pages` (the current Pages source — site at the branch root, `.nojekyll` emitted by `sphinx.ext.githubpages`, no CNAME to clobber).
- **On pull requests to `master`** — builds only (deploy step gated on `github.ref == refs/heads/master`), so doc breakage is caught before merge. This PR therefore self-validates the workflow.
- **`workflow_dispatch`** — manual "redeploy now" button.

Also adds a `docs` optional-dependency group to `pyproject.toml` (`sphinx, furo, sphinx-click, sphinx-mdinclude, nbsphinx, alabaster, ipython`) so the toolchain is declared and installable via `pip install -e .[docs]`; the workflow installs `.[all,docs]`.

## Validation

Built locally with the workflow's exact commands (`pip install -e ".[all,docs]"` + `sphinx-build -W -b html docs/source docs/_build/html`): **build succeeded**, output contains `index.html` and `.nojekyll`. The example notebook ships with saved outputs so nbsphinx does not re-execute it (`pandoc` is the only extra system dep, installed in the job).

## Notes

- The manual `make full` path still works; this just automates it.
- Requires the repo's Pages source to remain "Deploy from branch → `gh-pages`" (unchanged).

https://claude.ai/code/session_01JKbhASQT3f4MRAJbTfkCph

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKbhASQT3f4MRAJbTfkCph)_